### PR TITLE
stabilityDaysを引き上げる

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,10 +8,10 @@
     "enabled": true
   },
   "major": {
-    "stabilityDays": 14
+    "minimumReleaseAge": "18 days"
   },
   "minor": {
-    "stabilityDays": 7
+    "minimumReleaseAge": "9 days"
   },
   "packageRules": [
     {
@@ -28,7 +28,7 @@
   "patch": {
     "groupName": "dependencies (patch)",
     "groupSlug": "patch",
-    "stabilityDays": 3
+    "minimumReleaseAge": "6 days"
   },
   "platformAutomerge": true,
   "postUpdateOptions": ["yarnDedupeFewer"],


### PR DESCRIPTION
背景: https://scrapbox.io/herp-inc/%E5%B7%A5%E5%AE%89Q%E8%AA%B2_%E5%AE%9A%E4%BE%8B_2023Q4#65b20096020f6c0000adcb73


> This feature used to be called stabilityDays.

https://docs.renovatebot.com/configuration-options/#minimumreleaseage

名前が変わっていたのでそちらに追従しました